### PR TITLE
Bug fix regarding use of unique_ptr instead of shared_ptr

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -37,10 +37,10 @@ int main(int argc, char* argv[])
 
     boost::asio::io_service io_service;
 
-    std::map<std::string, std::string> todo_delete;
-
+    std::map<std::string, std::shared_ptr<RequestHandler>>handler_map = info.handler_map;
+    //std::map<std::string, std::string> todo_delete;
     // create and start server
-    server s(io_service, info.port, todo_delete);
+    server s(io_service, info.port, handler_map);
     io_service.run();
   }
   catch (std::exception& e)

--- a/server.cpp
+++ b/server.cpp
@@ -3,7 +3,7 @@
 // Note: boost documentation referrenced to create server class
 
 server::server(boost::asio::io_service& io_service, short port,
-    std::map <std::string, std::string> function_mapping)
+    std::map <std::string, std::shared_ptr<RequestHandler>> function_mapping)
   : io_service_(io_service),
     acceptor_(io_service, tcp::endpoint(tcp::v4(), port))
 {
@@ -18,7 +18,7 @@ server::server(boost::asio::io_service& io_service, short port,
 
 void server::handle_accept(session* new_session,
     const boost::system::error_code& error,
-    std::map <std::string, std::string> function_mapping)
+    std::map <std::string, std::shared_ptr<RequestHandler>> function_mapping)
 {
   if (!error)
   {

--- a/server.h
+++ b/server.h
@@ -15,9 +15,9 @@ class server {
 
 public:
   server(boost::asio::io_service& io_service, short port,
-  		std::map<std::string, std::string> function_mapping);
+  		std::map<std::string, std::shared_ptr<RequestHandler>> function_mapping);
   void handle_accept(session* new_session, const boost::system::error_code& error,
-  		std::map <std::string, std::string> function_mapping);
+  		std::map <std::string, std::shared_ptr<RequestHandler>> function_mapping);
 
 private:
   boost::asio::io_service& io_service_;

--- a/session.cpp
+++ b/session.cpp
@@ -10,7 +10,7 @@
 #include <memory>
 
 session::session(boost::asio::io_service& io_service,
-  std::map <std::string, std::string> function_mapping)
+  std::map <std::string, std::shared_ptr<RequestHandler>> function_mapping)
   : socket_(io_service), function_mapping(function_mapping) {}
 
 tcp::socket& session::socket()

--- a/session.h
+++ b/session.h
@@ -16,7 +16,8 @@ using boost::asio::ip::tcp;
 class session
 {
 public:
-  session(boost::asio::io_service& io_service, std::map <std::string, std::string> function_mapping);
+  session(boost::asio::io_service& io_service, 
+    std::map <std::string, std::shared_ptr<RequestHandler>> function_mapping);
   tcp::socket& socket();
   void start();
   // handles requests by seeing which type of response is required
@@ -29,7 +30,7 @@ private:
   std::string get_function_from_url(std::string url);
 
   tcp::socket socket_;
-  std::map <std::string, std::string> function_mapping;
+  std::map <std::string, std::shared_ptr<RequestHandler>> function_mapping;
   boost::asio::streambuf buffer;
 };
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -23,12 +23,12 @@ ServerInfo setup_info_struct(NginxConfig config) {
             std::string uri_prefix = config.statements_[i]->tokens_[1];
             std::string handler_name = config.statements_[i]->tokens_[2];
 
-            std::unique_ptr<RequestHandler> handler;
+            std::shared_ptr<RequestHandler> handler;
 
             if (handler_name == "EchoHandler") {
-                handler = std::unique_ptr<RequestHandler>(new EchoHandler);
+                handler = std::shared_ptr<RequestHandler>(new EchoHandler);
             } else { //if (handler_name == "StaticHandler") {
-                handler = std::unique_ptr<RequestHandler>(new StaticHandler);
+                handler = std::shared_ptr<RequestHandler>(new StaticHandler);
             }
             // else {
             //     // TODO return 404 handler

--- a/utils.h
+++ b/utils.h
@@ -11,7 +11,7 @@ struct ServerInfo {
 
     // map that maps url prefix to handler
     // Ex. "/echo" -> EchoHandler
-    std::map <std::string, std::unique_ptr<RequestHandler>> handler_map;
+    std::map <std::string, std::shared_ptr<RequestHandler>> handler_map;
 };
 
 namespace utils {


### PR DESCRIPTION
Changed our mapping to string to function handlers to use shared_ptr instead. Allows movement of the memory down to the session class, which is what we need. Might need to think about sending a pointer to the map around instead of the map itself, but for now this works!